### PR TITLE
Fix TypeScript definitions and clinical export flows

### DIFF
--- a/packages/design-system/tsconfig.json
+++ b/packages/design-system/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "dist",
+    "noEmit": false,
     "tsBuildInfoFile": "./.tsbuildinfo"
   },
   "include": ["src/**/*"]

--- a/src/components/export/ClinicalPDFExportButton.tsx
+++ b/src/components/export/ClinicalPDFExportButton.tsx
@@ -53,13 +53,16 @@ export const ClinicalPDFExportButton: React.FC<ClinicalPDFExportButtonProps> = (
 
       // Generate PDF
       const exporter = new ClinicalPDFExporter();
-      await exporter.generateReport(
+      await exporter.generateReport({
         entries,
         patientInfo,
         moodEntries,
-        chartImages['pain-trend-chart'],
-        chartImages['pain-distribution-chart']
-      );
+        charts: {
+          painTrend: chartImages['pain-trend-chart'],
+          painDistribution: chartImages['pain-distribution-chart'],
+        },
+        includeNarrative: true,
+      });
 
       // Success feedback
       if ('vibrate' in navigator) {

--- a/src/components/tutorials/Walkthrough.tsx
+++ b/src/components/tutorials/Walkthrough.tsx
@@ -6,7 +6,7 @@ import { useState, useEffect, useRef } from 'react';
 import { ArrowLeft, ArrowRight, X } from 'lucide-react';
 import { Button } from '../../design-system';
 
-interface WalkthroughStep {
+export interface WalkthroughStep {
   target: string; // CSS selector for the target element
   title: string;
   content: string;

--- a/src/containers/PainTrackerContainer.tsx
+++ b/src/containers/PainTrackerContainer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, lazy, Suspense } from 'react';
 import { secureStorage } from '../lib/storage/secureStorage';
 import type { PainEntry } from '../types';
-import type { WalkthroughStep } from '../types';
+import type { WalkthroughStep } from '../components/tutorials/Walkthrough';
 import { usePainTrackerStore } from '../stores/pain-tracker-store';
 import { TraumaInformedPainTrackerLayout } from '../components/layouts/TraumaInformedPainTrackerLayout';
 import { useToast } from '../components/feedback';

--- a/src/services/AdvancedAnalyticsEngine.test.ts
+++ b/src/services/AdvancedAnalyticsEngine.test.ts
@@ -17,16 +17,22 @@ describe('AdvancedAnalyticsEngine', () => {
       timestamp.setDate(timestamp.getDate() - i);
       timestamp.setHours(8 + (i % 12), 0, 0, 0);
 
+      const intensity = 3 + (i % 7);
       return {
         id: i + 1,
         timestamp: timestamp.toISOString(),
-        intensity: 3 + (i % 7),
+        intensity,
         location: 'Lower Back',
         quality: ['sharp', 'throbbing'],
         triggers: i % 3 === 0 ? ['sitting', 'stress'] : ['weather'],
         reliefMethods: i % 2 === 0 ? ['medication', 'rest'] : ['stretching'],
         activityLevel: 5 + (i % 5),
         notes: `Test entry ${i}`,
+        baselineData: {
+          pain: intensity,
+          locations: ['Lower Back'],
+          symptoms: ['sharp', 'throbbing'],
+        },
       };
     });
 
@@ -263,6 +269,11 @@ describe('AdvancedAnalyticsEngine', () => {
           quality: [],
           triggers: [],
           reliefMethods: [],
+          baselineData: {
+            pain: 4,
+            locations: ['Back'],
+            symptoms: [],
+          },
         },
         {
           id: 2,
@@ -272,6 +283,11 @@ describe('AdvancedAnalyticsEngine', () => {
           quality: [],
           triggers: [],
           reliefMethods: [],
+          baselineData: {
+            pain: 8,
+            locations: ['Back'],
+            symptoms: [],
+          },
         },
         ...mockEntries, // Add more for sufficient data
       ];
@@ -412,6 +428,11 @@ describe('AdvancedAnalyticsEngine', () => {
           quality: [],
           triggers: [],
           reliefMethods: [],
+          baselineData: {
+            pain: 5,
+            locations: ['Back'],
+            symptoms: [],
+          },
         },
       ];
       

--- a/src/types/pain-tracker.ts
+++ b/src/types/pain-tracker.ts
@@ -1,0 +1,49 @@
+import type { PainEntry as DetailedPainEntry } from '../types';
+
+/**
+ * Pain tracker specific typings used by the advanced analytics and export
+ * services. The types extend the broader application definitions with the
+ * additional fields these modules expect while remaining compatible with the
+ * data collected in the core tracker experience.
+ */
+
+export interface PainEntry extends DetailedPainEntry {
+  /**
+   * Explicit numeric intensity (0-10). Falls back to baselineData.pain when
+   * not provided so legacy entries remain compatible.
+   */
+  intensity?: number;
+  /**
+   * Primary location descriptor used for clinical summaries.
+   */
+  location?: string;
+  /**
+   * Descriptors describing the character/quality of the pain.
+   */
+  quality?: string[];
+  /**
+   * Recorded triggers that preceded the entry.
+   */
+  triggers?: string[];
+  /**
+   * Interventions or actions attempted for relief.
+   */
+  reliefMethods?: string[];
+  /**
+   * Optional activity level used by analytics modules.
+   */
+  activityLevel?: number;
+}
+
+/**
+ * Minimal mood entry representation required by the clinical export and
+ * analytics layers.  It deliberately keeps only the properties these modules
+ * consume to avoid importing the considerably larger quantified empathy type.
+ */
+export interface MoodEntry {
+  id?: string | number;
+  timestamp: string | Date;
+  mood: number;
+  notes?: string;
+}
+

--- a/src/utils/pwa-utils.ts
+++ b/src/utils/pwa-utils.ts
@@ -21,6 +21,11 @@ interface SyncManager {
   register(tag: string): Promise<void>;
 }
 
+type MaybeForceSync = {
+  forceSync?: () => Promise<unknown>;
+  forcSync?: () => Promise<unknown>;
+};
+
 interface PWACapabilities {
   serviceWorker: boolean;
   pushNotifications: boolean;
@@ -343,9 +348,8 @@ export class PWAManager {
     if (isOnline) {
       // Trigger background sync when coming back online
       try {
+        const { backgroundSync } = await import('../lib/background-sync');
         // Support legacy typo (forcSync) and future corrected (forceSync)
-  // cspell:ignore forc
-  type MaybeForceSync = { forceSync?: () => Promise<unknown>; forcSync?: () => Promise<unknown> };
         const svc = backgroundSync as unknown as MaybeForceSync;
         if (typeof svc.forceSync === 'function') {
           await svc.forceSync();


### PR DESCRIPTION
## Summary
- ensure the design system build config allows emitting so workspace type checks succeed
- add dedicated pain-tracker type definitions and update analytics/pdf services to fall back to legacy baseline data
- load sample onboarding data dynamically, type the walkthrough steps, and safely import background sync utilities

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e4a786a33c83208ec6da75f122e688