### PR TITLE
Fix mutation check workflow configuration

### DIFF
--- a/.github/workflows/mutation-check.yml
+++ b/.github/workflows/mutation-check.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Run focused Stryker (non-blocking)
         run: |
-          npx stryker run --config stryker.conf.cjs --logLevel info || true
+          npx stryker run stryker.conf.cjs --logLevel info || true
 
       - name: Upload mutation report
         uses: actions/upload-artifact@v4
@@ -35,7 +35,7 @@ jobs:
         with:
           script: |
             const summary = 'Mutation testing run completed. Artifact `mutation-report` uploaded.';
-            github.issues.createComment({
+            github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,


### PR DESCRIPTION
## Summary
- remove the unsupported `--config` flag from the mutation workflow's Stryker command
- update the summary comment step to use `github.rest.issues.createComment`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4ad6e6c1083208508c5bb0b54fdad