### PR TITLE
security(redzone): Harden local storage + egress gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **PWA Backups**: Stopped exporting/restoring pending sync queue items to prevent backup files from reintroducing network operations.
+- **Background Sync**: Restricted sync-queue replays to same-origin API endpoints and sanitized replayed headers.
+- **Analytics**: Prevented loading remote GA4 scripts until both build-time enablement and explicit user consent are present.
+
 ### Planned
 
 - Machine learning pain pattern recognition (Q1 2026)

--- a/index.html
+++ b/index.html
@@ -41,13 +41,7 @@
     <link rel="apple-touch-icon" href="./apple-touch-icon.png" />
     <link rel="manifest" href="./manifest.json" />
     
-    <!-- Font preconnect for performance -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    
-    <!-- DNS prefetch for external resources -->
-    <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
-    <link rel="dns-prefetch" href="https://fonts.gstatic.com" />
+    <!-- NOTE: Avoid preconnect/dns-prefetch to third-parties by default -->
     
     <title>Pain Tracker - Comprehensive Pain & Injury Management System</title>
     

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -123,9 +123,6 @@ function App() {
         } catch {
           // Background sync not available - this is expected in some environments
         }
-
-        // Setup health data sync if possible
-        await pwaManager.enableHealthDataSync();
       } catch {
         // Continue without PWA features - trauma-informed UX still works
       }

--- a/src/analytics/analytics-gate.ts
+++ b/src/analytics/analytics-gate.ts
@@ -1,0 +1,46 @@
+import { ANALYTICS_CONSENT_STORAGE_KEY } from '../stores/encrypted-idb-persist';
+
+export type AnalyticsGateResult = {
+  envEnabled: boolean;
+  hasConsent: boolean;
+};
+
+function isEnvEnabled(): boolean {
+  try {
+    if (import.meta.env && typeof import.meta.env.VITE_ENABLE_ANALYTICS === 'string') {
+      return import.meta.env.VITE_ENABLE_ANALYTICS === 'true';
+    }
+  } catch {
+    // ignore
+  }
+
+  try {
+    // Vitest / Node fallback
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const env = (typeof process !== 'undefined' ? (process as any).env : undefined) || {};
+    return env.VITE_ENABLE_ANALYTICS === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function readConsent(): boolean {
+  try {
+    const v = localStorage.getItem(ANALYTICS_CONSENT_STORAGE_KEY);
+    return v === 'granted';
+  } catch {
+    return false;
+  }
+}
+
+export function getAnalyticsGate(): AnalyticsGateResult {
+  return {
+    envEnabled: isEnvEnabled(),
+    hasConsent: readConsent(),
+  };
+}
+
+export function isAnalyticsAllowed(): boolean {
+  const gate = getAnalyticsGate();
+  return gate.envEnabled && gate.hasConsent;
+}

--- a/src/analytics/analytics-loader.test.ts
+++ b/src/analytics/analytics-loader.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// This suite enforces: no remote analytics script loads without consent.
+
+describe('analytics-loader consent gating', () => {
+  const originalEnv = process.env.VITE_ENABLE_ANALYTICS;
+
+  beforeEach(() => {
+    vi.resetModules();
+    document.head.querySelectorAll('script').forEach(s => s.remove());
+
+    // Reset loader state between tests.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).__pt_ga4_loaded;
+
+    // Make sure loader can read env in tests.
+    process.env.VITE_ENABLE_ANALYTICS = 'true';
+
+    try {
+      localStorage.removeItem('pain-tracker:analytics-consent');
+    } catch {
+      // ignore
+    }
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    if (originalEnv === undefined) delete process.env.VITE_ENABLE_ANALYTICS;
+    else process.env.VITE_ENABLE_ANALYTICS = originalEnv;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).__pt_ga4_loaded;
+
+    document.head.querySelectorAll('script').forEach(s => s.remove());
+  });
+
+  it('does not append GA script when consent is missing', async () => {
+    await import('./analytics-loader');
+
+    const scripts = Array.from(document.head.querySelectorAll('script'));
+    const hasGtag = scripts.some(s => (s.getAttribute('src') || '').includes('googletagmanager.com/gtag/js'));
+    expect(hasGtag).toBe(false);
+  });
+
+  it('appends GA script only when consent is granted', async () => {
+    localStorage.setItem('pain-tracker:analytics-consent', 'granted');
+
+    await import('./analytics-loader');
+
+    const scripts = Array.from(document.head.querySelectorAll('script'));
+    const hasGtag = scripts.some(s => (s.getAttribute('src') || '').includes('googletagmanager.com/gtag/js'));
+    expect(hasGtag).toBe(true);
+  });
+
+  it('does not append duplicates when called multiple times', async () => {
+    localStorage.setItem('pain-tracker:analytics-consent', 'granted');
+
+    const mod = await import('./analytics-loader');
+    mod.loadAnalyticsIfAllowed();
+    mod.loadAnalyticsIfAllowed();
+
+    const scripts = Array.from(document.head.querySelectorAll('script'));
+    const gtagScripts = scripts.filter(s => (s.getAttribute('src') || '').includes('googletagmanager.com/gtag/js'));
+    expect(gtagScripts.length).toBe(1);
+  });
+});

--- a/src/analytics/ga4-events.ts
+++ b/src/analytics/ga4-events.ts
@@ -7,6 +7,7 @@
  */
 
 // Window.gtag is declared in analytics-loader.ts - use that type
+import { isAnalyticsAllowed } from './analytics-gate';
 
 /**
  * GA4 Event Names - following GA4 recommended event naming conventions
@@ -117,7 +118,12 @@ export interface GA4EventParams {
  * Check if GA4 is available and enabled
  */
 function isGA4Available(): boolean {
-  return typeof window !== 'undefined' && typeof window.gtag === 'function';
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.gtag === 'function' &&
+    // Defense-in-depth: require env flag AND explicit user consent.
+    isAnalyticsAllowed()
+  );
 }
 
 /**

--- a/src/components/AnalyticsConsentPrompt.tsx
+++ b/src/components/AnalyticsConsentPrompt.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useRef } from 'react';
 import { useToast } from './feedback';
 import { privacyAnalytics } from '../services/PrivacyAnalyticsService';
 import { useStartupPrompts } from '../contexts/StartupPromptsContext';
+import { loadAnalyticsIfAllowed } from '../analytics/analytics-loader';
 
 const STORAGE_KEY = 'pain-tracker:analytics-consent';
 
@@ -54,6 +55,9 @@ export default function AnalyticsConsentPrompt() {
           // Enable analytics in the service
           const consentGranted = await privacyAnalytics.requestConsent();
 
+          // Load GA4 only after explicit opt-in.
+          loadAnalyticsIfAllowed();
+
           if (consentGranted) {
             bottomLeftRef.current.success(
               'Thank you!',
@@ -73,7 +77,7 @@ export default function AnalyticsConsentPrompt() {
         // When dismissed (X clicked), store 'declined'
         localStorage.setItem(STORAGE_KEY, 'declined');
         setConsent('declined');
-        privacyAnalytics.updatePrivacyConfig({ enableAnalytics: false });
+        privacyAnalytics.revokeConsent();
         dismissPromptRef.current('analytics-consent');
       };
 

--- a/src/components/accessibility/TraumaInformedDemo.tsx
+++ b/src/components/accessibility/TraumaInformedDemo.tsx
@@ -23,8 +23,7 @@ export function TraumaInformedDemo() {
         <div className="bg-white rounded-lg shadow-sm p-6">
           <TraumaInformedPainEntryForm
             onSubmit={entry => {
-              console.log('Pain entry submitted:', entry);
-              // In demo mode, just log the submission
+              // Demo mode: intentionally no logging of submitted data
             }}
           />
         </div>

--- a/src/components/pain-tracker/PainTracker.test.tsx
+++ b/src/components/pain-tracker/PainTracker.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, beforeAll, afterEach, afterAll, vi } from 'vitest';
 import { render, screen, fireEvent } from '../../test/test-utils'; // Use custom render with providers
+import { waitFor } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { PainTracker } from './index';
 import { ToastProvider } from '../feedback';
@@ -330,8 +331,10 @@ describe('PainTracker', () => {
 
       render(<PainTracker />, { wrapper: TestWrapper });
 
-      // Should show an error message (async effect)
-      expect(await screen.findByText(/Unable to load pain entries/i)).toBeInTheDocument();
+      // Canonical storage is store-backed; localStorage failures should not break rendering.
+      await waitFor(() => {
+        expect(screen.queryByText(/Unable to load pain entries/i)).not.toBeInTheDocument();
+      });
 
       // Should still render the form for new entries
       expect(screen.getByText(/Record Pain Entry/i)).toBeInTheDocument();

--- a/src/components/pain-tracker/index.tsx
+++ b/src/components/pain-tracker/index.tsx
@@ -214,15 +214,21 @@ export function PainTracker() {
 
   // Handle localStorage separately to catch errors
   useEffect(() => {
+    let cancelled = false;
     (async () => {
       try {
         const loaded = await loadPainEntries();
+        if (cancelled) return;
         setEntries(loaded);
       } catch (err) {
+        if (cancelled) return;
         setError('Unable to load pain entries. Please try refreshing the page.');
         console.error('Error loading pain entries:', err);
       }
     })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // Focus management for WCB report

--- a/src/services/AnalyticsTrackingService.ts
+++ b/src/services/AnalyticsTrackingService.ts
@@ -16,9 +16,16 @@ declare global {
   }
 }
 
+import { isAnalyticsAllowed } from '../analytics/analytics-gate';
+
 // Check if analytics is available
 function isAnalyticsEnabled(): boolean {
-  return typeof window !== 'undefined' && typeof window.gtag === 'function';
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.gtag === 'function' &&
+    // Defense-in-depth: require env flag AND explicit user consent.
+    isAnalyticsAllowed()
+  );
 }
 
 // Safe gtag wrapper

--- a/src/services/FHIRService.ts
+++ b/src/services/FHIRService.ts
@@ -265,6 +265,15 @@ export class FHIRService {
     };
   }
 
+  private assertConfigured(operation: string): void {
+    if (!this.baseUrl) {
+      throw new Error(
+        `FHIRService is not configured for network calls (${operation}). ` +
+          'Provide a baseUrl when constructing FHIRService.'
+      );
+    }
+  }
+
   // Convert Pain Entry to FHIR Observation
   painEntryToFHIRObservation(entry: PainEntry, patientId?: string): FHIRObservation {
     const painObservation: FHIRObservation = {
@@ -533,6 +542,7 @@ export class FHIRService {
 
   // API Methods for FHIR Server Integration
   async createResource(resource: FHIRResource): Promise<FHIRResource> {
+    this.assertConfigured('createResource');
     const response = await fetch(`${this.baseUrl}/${resource.resourceType}`, {
       method: 'POST',
       headers: this.headers,
@@ -547,6 +557,7 @@ export class FHIRService {
   }
 
   async updateResource(resource: FHIRResource): Promise<FHIRResource> {
+    this.assertConfigured('updateResource');
     if (!resource.id) {
       throw new Error('Resource must have an ID for update operation');
     }
@@ -565,6 +576,7 @@ export class FHIRService {
   }
 
   async getResource(resourceType: string, id: string): Promise<FHIRResource> {
+    this.assertConfigured('getResource');
     const response = await fetch(`${this.baseUrl}/${resourceType}/${id}`, {
       method: 'GET',
       headers: this.headers,
@@ -578,6 +590,7 @@ export class FHIRService {
   }
 
   async searchResources(resourceType: string, params: Record<string, string>): Promise<FHIRBundle> {
+    this.assertConfigured('searchResources');
     const searchParams = new URLSearchParams(params);
     const response = await fetch(`${this.baseUrl}/${resourceType}?${searchParams}`, {
       method: 'GET',
@@ -592,6 +605,7 @@ export class FHIRService {
   }
 
   async deleteResource(resourceType: string, id: string): Promise<void> {
+    this.assertConfigured('deleteResource');
     const response = await fetch(`${this.baseUrl}/${resourceType}/${id}`, {
       method: 'DELETE',
       headers: this.headers,
@@ -604,6 +618,7 @@ export class FHIRService {
 
   // Bulk operations
   async submitBundle(bundle: FHIRBundle): Promise<FHIRBundle> {
+    this.assertConfigured('submitBundle');
     const response = await fetch(`${this.baseUrl}`, {
       method: 'POST',
       headers: this.headers,
@@ -619,6 +634,7 @@ export class FHIRService {
 
   // Validation
   async validateResource(resource: FHIRResource): Promise<FHIRValidationResult> {
+    this.assertConfigured('validateResource');
     const response = await fetch(`${this.baseUrl}/${resource.resourceType}/$validate`, {
       method: 'POST',
       headers: this.headers,

--- a/src/services/__tests__/fhirService-egress-guard.test.ts
+++ b/src/services/__tests__/fhirService-egress-guard.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FHIRService } from '../FHIRService';
+
+describe('FHIRService egress guard', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('throws when baseUrl is not configured for network calls', async () => {
+    const svc = new FHIRService('');
+    const fetchSpy = vi.spyOn(globalThis, 'fetch' as never);
+
+    await expect(
+      svc.createResource({ resourceType: 'Observation' })
+    ).rejects.toThrow(/not configured/i);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/stores/encrypted-idb-persist.ts
+++ b/src/stores/encrypted-idb-persist.ts
@@ -1,0 +1,279 @@
+import type { PersistStorage } from 'zustand/middleware';
+import { offlineStorage } from '../lib/offline-storage';
+import { encryptionService } from '../services/EncryptionService';
+import { secureStorage } from '../lib/storage/secureStorage';
+
+const LEGACY_PAIN_ENTRIES_KEYS = {
+  // Zustand persist (plaintext localStorage)
+  zustand: 'pain-tracker-storage',
+  // Legacy pain tracker utilities
+  legacyEntries: 'pain_tracker_entries',
+  // Older key used by some onboarding migration logic
+  olderEntries: 'painEntries',
+} as const;
+
+export const ANALYTICS_CONSENT_STORAGE_KEY = 'pain-tracker:analytics-consent';
+
+function getSafeLocalStorage(): Storage | undefined {
+  try {
+    return typeof localStorage === 'undefined' ? undefined : localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+function safeJsonParse<T>(raw: string): T | null {
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+function readLegacyPainEntries(): unknown[] | null {
+  // Try legacy encrypted localStorage via secureStorage first (does not throw if hooks missing)
+  try {
+    const stored = secureStorage.get<unknown>(LEGACY_PAIN_ENTRIES_KEYS.legacyEntries, { encrypt: true });
+    if (Array.isArray(stored)) return stored;
+  } catch {
+    // ignore
+  }
+
+  // Then try plain localStorage keys
+  const ls = getSafeLocalStorage();
+  if (!ls) return null;
+
+  const rawLegacy = ls.getItem(LEGACY_PAIN_ENTRIES_KEYS.legacyEntries);
+  if (rawLegacy) {
+    const parsed = safeJsonParse<unknown>(rawLegacy);
+    if (Array.isArray(parsed)) return parsed;
+  }
+
+  const rawOlder = ls.getItem(LEGACY_PAIN_ENTRIES_KEYS.olderEntries);
+  if (rawOlder) {
+    const parsed = safeJsonParse<unknown>(rawOlder);
+    if (Array.isArray(parsed)) return parsed;
+  }
+
+  return null;
+}
+
+function clearLegacyPainEntriesKeys(): void {
+  const ls = getSafeLocalStorage();
+  try {
+    secureStorage.remove(LEGACY_PAIN_ENTRIES_KEYS.legacyEntries, { encrypt: true });
+  } catch {
+    // ignore
+  }
+  if (!ls) return;
+  try {
+    ls.removeItem(LEGACY_PAIN_ENTRIES_KEYS.legacyEntries);
+  } catch {
+    // ignore
+  }
+  try {
+    ls.removeItem(LEGACY_PAIN_ENTRIES_KEYS.olderEntries);
+  } catch {
+    // ignore
+  }
+}
+
+export function createEncryptedOfflinePersistStorage<TState>(
+  name: string,
+  options?: {
+    /** IDB settings key override. Defaults to `zustand:persist:${name}` */
+    idbKey?: string;
+    /** Optional migration hook called when legacy entries are detected */
+    buildMigratedState?: (legacyEntries: unknown[]) => { state: TState; version?: number };
+  }
+): PersistStorage<TState> {
+  const idbKey = options?.idbKey ?? `zustand:persist:${name}`;
+
+  // Serialize operations per storage instance so callers can reliably await
+  // completion (e.g. tests calling `persist.clearStorage()`), and to prevent
+  // races where an older async write removes newly-seeded legacy localStorage.
+  let opChain: Promise<unknown> = Promise.resolve();
+  const runExclusive = <T>(fn: () => Promise<T>): Promise<T> => {
+    const next = opChain.then(fn, fn);
+    // Keep the chain alive even if this operation fails.
+    opChain = next.then(
+      () => undefined,
+      () => undefined
+    );
+    return next;
+  };
+
+  async function findRowId(): Promise<number | null> {
+    const rows = await offlineStorage.getData('settings');
+    const match = rows.find(
+      r =>
+        r.data &&
+        typeof r.data === 'object' &&
+        'key' in r.data &&
+        (r.data as Record<string, unknown>).key === idbKey
+    );
+    return match?.id ?? null;
+  }
+
+  async function readEncryptedValue(): Promise<unknown | null> {
+    const rows = await offlineStorage.getData('settings');
+    const match = rows.find(
+      r =>
+        r.data &&
+        typeof r.data === 'object' &&
+        'key' in r.data &&
+        (r.data as Record<string, unknown>).key === idbKey
+    );
+    if (!match) return null;
+
+    const payload = (match.data as Record<string, unknown>).value;
+    if (!payload) return null;
+
+    return payload;
+  }
+
+  async function writeEncryptedValue(value: unknown): Promise<void> {
+    const rows = await offlineStorage.getData('settings');
+    const match = rows.find(
+      r =>
+        r.data &&
+        typeof r.data === 'object' &&
+        'key' in r.data &&
+        (r.data as Record<string, unknown>).key === idbKey
+    );
+
+    if (match?.id !== undefined) {
+      try {
+        await offlineStorage.updateData(match.id, { key: idbKey, value } as unknown as Record<string, unknown>);
+      } catch {
+        // IndexedDB can legitimately race in test environments (or if another
+        // cleanup runs between read and update). Fall back to add.
+        await offlineStorage.storeData('settings', { key: idbKey, value } as unknown as Record<string, unknown>);
+      }
+    } else {
+      await offlineStorage.storeData('settings', { key: idbKey, value } as unknown as Record<string, unknown>);
+    }
+  }
+
+  async function removeEncryptedValue(): Promise<void> {
+    const rowId = await findRowId();
+    if (rowId !== null) {
+      await offlineStorage.deleteData(rowId);
+    }
+  }
+
+  async function tryMigrateFromLegacyLocalStorage(): Promise<{ state: TState; version?: number } | null> {
+    // 1) old zustand persist (plaintext localStorage)
+    const ls = getSafeLocalStorage();
+    if (ls) {
+      const raw = ls.getItem(name);
+      if (raw) {
+        const parsed = safeJsonParse<{ state: TState; version?: number }>(raw);
+        if (parsed) {
+          // Best-effort: store encrypted and then remove plaintext
+          try {
+            const encrypted = await encryptionService.encrypt(parsed, {
+              useCompression: true,
+              addIntegrityCheck: true,
+            });
+            await writeEncryptedValue(encrypted);
+            try {
+              ls.removeItem(name);
+            } catch {
+              // ignore
+            }
+          } catch {
+            // If encryption fails, fall through; returning parsed would keep app working but would
+            // re-persist and retry encryption later.
+          }
+          return parsed;
+        }
+
+        // Corrupted JSON: clear and continue
+        try {
+          ls.removeItem(name);
+        } catch {
+          // ignore
+        }
+      }
+    }
+
+    // 2) legacy pain entries arrays
+    const legacyEntries = readLegacyPainEntries();
+    if (legacyEntries && options?.buildMigratedState) {
+      const migrated = options.buildMigratedState(legacyEntries);
+      try {
+        const encrypted = await encryptionService.encrypt(migrated, {
+          useCompression: true,
+          addIntegrityCheck: true,
+        });
+        await writeEncryptedValue(encrypted);
+        clearLegacyPainEntriesKeys();
+      } catch {
+        // ignore encryption failures; we'll still return migrated to keep UX alive
+      }
+      return migrated;
+    }
+
+    // 3) nothing to migrate
+    return null;
+  }
+
+  return {
+    getItem: async (_storageName: string) => runExclusive(async () => {
+      // First: try encrypted IDB.
+      try {
+        const storedEncrypted = await readEncryptedValue();
+        if (storedEncrypted) {
+          const decrypted = await encryptionService.decrypt(storedEncrypted as never);
+          return decrypted as { state: TState; version?: number };
+        }
+      } catch {
+        // If decrypt fails, clear and fall back to migration (best-effort)
+        try {
+          await removeEncryptedValue();
+        } catch {
+          // ignore
+        }
+      }
+
+      // Second: try migration from legacy sources.
+      const migrated = await tryMigrateFromLegacyLocalStorage();
+      return migrated;
+    }),
+
+    setItem: async (_storageName: string, value: { state: TState; version?: number }) => runExclusive(async () => {
+      const encrypted = await encryptionService.encrypt(value, {
+        useCompression: true,
+        addIntegrityCheck: true,
+      });
+      await writeEncryptedValue(encrypted);
+
+      // Best-effort: remove any plaintext legacy copies.
+      const ls = getSafeLocalStorage();
+      if (ls) {
+        try {
+          ls.removeItem(name);
+        } catch {
+          // ignore
+        }
+      }
+      clearLegacyPainEntriesKeys();
+    }),
+
+    removeItem: async (_storageName: string) => runExclusive(async () => {
+      try {
+        await removeEncryptedValue();
+      } catch {
+        // ignore
+      }
+      const ls = getSafeLocalStorage();
+      if (!ls) return;
+      try {
+        ls.removeItem(name);
+      } catch {
+        // ignore
+      }
+    }),
+  };
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -26,9 +26,8 @@
 @import 'tailwindcss/utilities';
 
 /* ===== FONTS ===== */
-/* PERFORMANCE: Font preconnect is in index.html for faster discovery.
- * display=swap ensures text is visible while font loads (FOUT over FOIT). */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap');
+/* NOTE: Avoid remote font loading by default (no silent network egress).
+ * Font stacks should rely on local/system fonts unless explicitly approved. */
 
 /* ===== DESIGN SYSTEM ===== */
 @import '../design-system/tokens/fused-v2.css';

--- a/src/test/background-sync-guard.test.ts
+++ b/src/test/background-sync-guard.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Vitest hoists vi.mock() calls, so any referenced values must be created via vi.hoisted().
+const offlineStorageMocks = vi.hoisted(() => ({
+  getSyncQueue: vi.fn<() => Promise<Array<any>>>(),
+  addToSyncQueue: vi.fn().mockResolvedValue(1),
+  removeSyncQueueItem: vi.fn<(id: number) => Promise<void>>(),
+  updateSyncQueueItem: vi.fn().mockResolvedValue(undefined),
+  getUnsyncedData: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../lib/offline-storage', () => ({
+  offlineStorage: offlineStorageMocks,
+}));
+
+// Import after mocks.
+import { backgroundSync } from '../lib/background-sync';
+
+function okResponse() {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => ({}),
+  } as unknown as Response;
+}
+
+describe('background sync replay guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Ensure async mocks have sensible defaults for each test.
+    offlineStorageMocks.getUnsyncedData.mockResolvedValue([]);
+    offlineStorageMocks.updateSyncQueueItem.mockResolvedValue(undefined);
+    offlineStorageMocks.removeSyncQueueItem.mockResolvedValue(undefined);
+    offlineStorageMocks.addToSyncQueue.mockResolvedValue(1);
+
+    // Ensure the singleton considers us online.
+    (backgroundSync as any).isOnline = true;
+    (backgroundSync as any).syncInProgress = false;
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okResponse()));
+  });
+
+  it('drops and never replays cross-origin queue items', async () => {
+    offlineStorageMocks.getSyncQueue.mockResolvedValueOnce([
+      {
+        id: 1,
+        url: 'https://evil.example/collect',
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{"x":1}',
+        priority: 'high',
+        type: 'api-request',
+        retryCount: 0,
+        timestamp: new Date().toISOString(),
+      },
+    ]);
+
+    const stats = await backgroundSync.syncAllPendingData();
+
+    expect((globalThis.fetch as any)).not.toHaveBeenCalled();
+    expect(offlineStorageMocks.removeSyncQueueItem).toHaveBeenCalledWith(1);
+    expect(stats.failureCount).toBe(1);
+  });
+
+  it('replays same-origin /api queue items', async () => {
+    offlineStorageMocks.getSyncQueue.mockResolvedValueOnce([
+      {
+        id: 2,
+        url: '/api/pain-entries',
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-Extra': 'nope' },
+        body: '{"pain":5}',
+        priority: 'high',
+        type: 'api-request',
+        retryCount: 0,
+        timestamp: new Date().toISOString(),
+      },
+    ]);
+
+    await backgroundSync.syncAllPendingData();
+
+    expect((globalThis.fetch as any)).toHaveBeenCalledTimes(1);
+    const call = (globalThis.fetch as any).mock.calls[0];
+    expect(call[0]).toBe('/api/pain-entries');
+
+    // Ensure header sanitization drops unexpected headers.
+    expect(call[1].headers).toEqual({ 'Content-Type': 'application/json' });
+  });
+
+  it('refuses to enqueue disallowed URLs', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await backgroundSync.queueForSync('https://evil.example/collect', 'POST', { x: 1 }, 'high');
+
+    expect(offlineStorageMocks.addToSyncQueue).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/src/test/pwa-registration.test.ts
+++ b/src/test/pwa-registration.test.ts
@@ -4,8 +4,6 @@ import { pwaManager } from '../utils/pwa-utils';
 vi.mock('../lib/offline-storage', () => ({
   offlineStorage: {
     init: vi.fn().mockResolvedValue(undefined),
-    exportData: vi.fn().mockResolvedValue({ syncQueue: [] }),
-    addToSyncQueue: vi.fn().mockResolvedValue(undefined),
     getStorageUsage: vi.fn().mockResolvedValue({ used: 0, quota: 0 }),
     clearAllData: vi.fn().mockResolvedValue(undefined),
   },

--- a/src/utils/privacySettings.ts
+++ b/src/utils/privacySettings.ts
@@ -11,7 +11,7 @@ export type PrivacySettings = {
 
 const DEFAULT_PRIVACY_SETTINGS: PrivacySettings = {
   dataSharing: false,
-  analyticsConsent: true,
+  analyticsConsent: false,
   retentionDays: 365,
   weatherAutoCapture: false,
 };


### PR DESCRIPTION
## Summary
Red-zone hardening to eliminate plaintext persistence paths and reduce silent egress risk for Class A data.

## Key changes
- Move pain-tracker persist backing store to encrypted IndexedDB (migration from legacy localStorage).
- Gate GA/analytics behind env flag + explicit consent; prevent GA script injection and event emission without consent.
- Constrain background sync queue/replay to allowlisted same-origin API paths; sanitize replay headers; exclude sync queue ops from backups.
- Add FHIR client baseUrl guard to prevent accidental network calls when unconfigured.
- Remove default Google Fonts preconnect/import to avoid automatic third-party requests.

## Verification
- `npm run check` on branch: tests + typecheck/lint + production build pass.

## Review notes
- These changes touch storage, sync, and analytics boundaries; please review carefully for privacy/security assumptions.