### PR TITLE
deps: Pin qs to 6.14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12775,9 +12775,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -234,5 +234,8 @@
   },
   "playwright": {
     "install": true
+  },
+  "overrides": {
+    "qs": "6.14.1"
   }
 }


### PR DESCRIPTION
Fixes GHSA-6rw7-vpxm-498p by forcing transitive qs to 6.14.1 via npm overrides.

- Scope: dependency/lockfile only (no runtime code changes)
- Verification: npm run check (typecheck, lint, tests, build)