### PR TITLE
[codex] Wire fibromyalgia navigation preference

### DIFF
--- a/src/components/layouts/ModernAppLayout.tsx
+++ b/src/components/layouts/ModernAppLayout.tsx
@@ -40,6 +40,7 @@ interface ModernAppLayoutProps {
     avgPain: number;
     streak: number;
   };
+  showFibromyalgiaNavItem?: boolean;
 }
 
 type NavigationItem = {
@@ -465,6 +466,7 @@ export function ModernAppLayout({
   onNavigate,
   currentView = 'dashboard',
   stats,
+  showFibromyalgiaNavItem = true,
 }: Readonly<ModernAppLayoutProps>) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [panicModeActive, setPanicModeActive] = useState(false);
@@ -475,6 +477,9 @@ export function ModernAppLayout({
   const themeClasses = getLayoutThemeClasses(isDark);
   const themeToggle = getThemeToggleProps(mode);
   const ThemeToggleIcon = themeToggle.icon;
+  const effectiveNavigation = showFibromyalgiaNavItem
+    ? NAVIGATION_ITEMS
+    : NAVIGATION_ITEMS.filter(item => item.id !== 'fibromyalgia');
 
   useEffect(() => {
     if (typeof document === 'undefined') return;
@@ -627,7 +632,7 @@ export function ModernAppLayout({
         isDark={isDark}
         onNavigate={onNavigate}
         bottomNavigation={BOTTOM_NAVIGATION_ITEMS}
-        navigation={NAVIGATION_ITEMS}
+        navigation={effectiveNavigation}
         inactiveDesktopNavClass={themeClasses.inactiveDesktopNavClass}
         activeBottomNavClass={themeClasses.activeBottomNavClass}
         inactiveBottomNavClass={themeClasses.inactiveBottomNavClass}
@@ -640,7 +645,7 @@ export function ModernAppLayout({
         isDark={isDark}
         onNavigate={onNavigate}
         bottomNavigation={BOTTOM_NAVIGATION_ITEMS}
-        navigation={NAVIGATION_ITEMS}
+        navigation={effectiveNavigation}
         inactiveMobileNavClass={themeClasses.inactiveMobileNavClass}
         activeBottomNavClass={themeClasses.activeBottomNavClass}
         inactiveMobileBottomNavClass={themeClasses.inactiveMobileBottomNavClass}

--- a/src/components/settings/WorkflowPreferencesPanel.tsx
+++ b/src/components/settings/WorkflowPreferencesPanel.tsx
@@ -74,6 +74,21 @@ export default function WorkflowPreferencesPanel() {
           />
         </label>
 
+        <label className="flex items-center justify-between gap-4">
+          <div>
+            <div className="font-medium text-gray-700 dark:text-slate-200">Show Fibromyalgia Hub in navigation</div>
+            <div className="text-sm text-gray-500 dark:text-slate-400">
+              Hide this top-level item if you do not want fibromyalgia-specific navigation in the main app menu.
+            </div>
+          </div>
+          <input
+            type="checkbox"
+            checked={preferences.showFibromyalgiaHubNavItem}
+            onChange={e => updatePreferences({ showFibromyalgiaHubNavItem: e.target.checked })}
+            className="h-5 w-5 rounded border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-emerald-500 focus:ring-emerald-500/50 focus:ring-offset-white dark:focus:ring-offset-slate-900"
+          />
+        </label>
+
         <p className="text-sm text-gray-500 dark:text-slate-400">
           These preferences only change local workflow defaults. They do not alter stored entries unless you explicitly log new information.
         </p>

--- a/src/containers/PainTrackerContainer.tsx
+++ b/src/containers/PainTrackerContainer.tsx
@@ -13,7 +13,11 @@ import { BrandedLoadingScreen } from '../components/branding/BrandedLoadingScree
 import { HistoryPage } from '../components/history/HistoryPage';
 import { subscriptionService } from '../services/SubscriptionService';
 import { getLocalUserId } from '../utils/user-identity';
-import { readWorkflowPreferences } from '../utils/workflowPreferences';
+import {
+  DEFAULT_WORKFLOW_PREFERENCES,
+  WORKFLOW_PREFERENCES_UPDATED_EVENT,
+  readWorkflowPreferences,
+} from '../utils/workflowPreferences';
 
 // Lazy load heavy components for faster initial load (mobile optimization)
 const AnalyticsDashboard = lazy(() =>
@@ -59,15 +63,36 @@ export function PainTrackerContainer({ initialView }: { initialView?: string } =
   const { entries, ui, addEntry, setShowOnboarding, setShowWalkthrough, setError, loadSampleData } =
     usePainTrackerStore();
   const updateEntry = usePainTrackerStore(s => s.updateEntry);
-  const workflowPreferences = typeof window === 'undefined' ? null : readWorkflowPreferences();
-  const industrialFieldMode = workflowPreferences?.industrialFieldMode ?? false;
+  const [workflowPreferences, setWorkflowPreferences] = useState(() =>
+    typeof window === 'undefined'
+      ? DEFAULT_WORKFLOW_PREFERENCES
+      : readWorkflowPreferences()
+  );
+  const industrialFieldMode = workflowPreferences.industrialFieldMode;
 
   const toast = useToast();
   const [walkthroughSteps, setWalkthroughSteps] = useState<WalkthroughStep[]>([]);
-  const [currentView, setCurrentView] = useState<string>(() =>
-    initialView ?? (industrialFieldMode || entries.length === 0 ? 'new-entry' : 'dashboard')
-  );
+  const [currentView, setCurrentView] = useState<string>(() => {
+    const defaultView = initialView ?? (industrialFieldMode || entries.length === 0 ? 'new-entry' : 'dashboard');
+    return workflowPreferences.showFibromyalgiaHubNavItem || defaultView !== 'fibromyalgia'
+      ? defaultView
+      : 'dashboard';
+  });
   const [editingEntryId, setEditingEntryId] = useState<PainEntry['id'] | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handlePreferencesUpdate = () => setWorkflowPreferences(readWorkflowPreferences());
+    window.addEventListener(WORKFLOW_PREFERENCES_UPDATED_EVENT, handlePreferencesUpdate);
+    return () => window.removeEventListener(WORKFLOW_PREFERENCES_UPDATED_EVENT, handlePreferencesUpdate);
+  }, []);
+
+  useEffect(() => {
+    if (!workflowPreferences.showFibromyalgiaHubNavItem && currentView === 'fibromyalgia') {
+      setCurrentView('dashboard');
+    }
+  }, [workflowPreferences.showFibromyalgiaHubNavItem, currentView]);
 
   // Load walkthrough steps dynamically to avoid circular dependency
   useEffect(() => {
@@ -168,6 +193,15 @@ export function PainTrackerContainer({ initialView }: { initialView?: string } =
 
   const handleWalkthroughSkip = () => {
     setShowWalkthrough(false);
+  };
+
+  const handleNavigate = (nextView: string) => {
+    if (nextView === 'fibromyalgia' && !workflowPreferences.showFibromyalgiaHubNavItem) {
+      setCurrentView('dashboard');
+      return;
+    }
+
+    setCurrentView(nextView);
   };
 
   const validatePainEntry = (entry: Omit<PainEntry, 'id' | 'timestamp'>): boolean => {
@@ -524,7 +558,12 @@ export function PainTrackerContainer({ initialView }: { initialView?: string } =
 
   return (
     <>
-      <ModernAppLayout currentView={currentView} onNavigate={setCurrentView} stats={stats}>
+      <ModernAppLayout
+        currentView={currentView}
+        onNavigate={handleNavigate}
+        stats={stats}
+        showFibromyalgiaNavItem={workflowPreferences.showFibromyalgiaHubNavItem}
+      >
         {renderView()}
       </ModernAppLayout>
 

--- a/src/containers/__tests__/PainTrackerContainer.test.tsx
+++ b/src/containers/__tests__/PainTrackerContainer.test.tsx
@@ -8,9 +8,11 @@ import { readWorkflowPreferences } from '../../utils/workflowPreferences';
 
 vi.mock('../../stores/pain-tracker-store');
 vi.mock('../../utils/workflowPreferences', () => ({
+  WORKFLOW_PREFERENCES_UPDATED_EVENT: 'workflow-preferences-updated',
   readWorkflowPreferences: vi.fn(() => ({
     defaultWcbTemplateStyle: 'hostile-bureaucracy',
     industrialFieldMode: false,
+    showFibromyalgiaHubNavItem: true,
   })),
 }));
 
@@ -23,11 +25,18 @@ vi.mock('../../design-system/fused-v2', () => ({
   ),
 }));
 
+type QuickLogOneScreenData = {
+  pain: number;
+  locations: string[];
+  symptoms: string[];
+  notes: string;
+};
+
 vi.mock('../../design-system/fused-v2/QuickLogOneScreen', () => ({
   default: function QuickLogOneScreenMock({
     onComplete,
   }: {
-    onComplete: (data: any) => void;
+    onComplete: (data: QuickLogOneScreenData) => void;
   }) {
     const [checked, setChecked] = React.useState(false);
     return (
@@ -83,6 +92,7 @@ describe('PainTrackerContainer - entry success toast', () => {
     vi.mocked(readWorkflowPreferences).mockReturnValue({
       defaultWcbTemplateStyle: 'hostile-bureaucracy',
       industrialFieldMode: true,
+      showFibromyalgiaHubNavItem: true,
     });
 
     const storeState = {
@@ -121,6 +131,7 @@ describe('PainTrackerContainer - entry success toast', () => {
     vi.mocked(readWorkflowPreferences).mockReturnValue({
       defaultWcbTemplateStyle: 'hostile-bureaucracy',
       industrialFieldMode: false,
+      showFibromyalgiaHubNavItem: true,
     });
 
     const storeState = {
@@ -152,6 +163,7 @@ describe('PainTrackerContainer - entry success toast', () => {
     vi.mocked(readWorkflowPreferences).mockReturnValue({
       defaultWcbTemplateStyle: 'hostile-bureaucracy',
       industrialFieldMode: false,
+      showFibromyalgiaHubNavItem: true,
     });
 
     const user = userEvent.setup();

--- a/src/containers/__tests__/PainTrackerContainer.workflow-preferences.test.tsx
+++ b/src/containers/__tests__/PainTrackerContainer.workflow-preferences.test.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { act, render, screen, waitFor } from '../../test/test-utils';
+import { PainTrackerContainer } from '../PainTrackerContainer';
+import { usePainTrackerStore } from '../../stores/pain-tracker-store';
+import {
+  WORKFLOW_PREFERENCES_STORAGE_KEY,
+  writeWorkflowPreferences,
+  type WorkflowPreferences,
+} from '../../utils/workflowPreferences';
+
+const storageState = vi.hoisted(() => ({
+  values: new Map<string, unknown>(),
+}));
+
+vi.mock('../../stores/pain-tracker-store');
+
+vi.mock('../../utils/user-identity', () => ({
+  getLocalUserId: () => 'workflow-preferences-test-user',
+}));
+
+vi.mock('../../design-system/fused-v2', () => ({
+  ClinicalDashboard: () => <div>Clinical Dashboard</div>,
+}));
+
+vi.mock('../../design-system/fused-v2/QuickLogOneScreen', () => ({
+  default: () => <div>Quick Log</div>,
+}));
+
+vi.mock('../../data/sampleData', () => ({
+  walkthroughSteps: [],
+}));
+
+vi.mock('../../services/weatherAutoCapture', () => ({
+  maybeCaptureWeatherForNewEntry: async () => null,
+}));
+
+vi.mock('../../lib/storage/secureStorage', () => ({
+  secureStorage: {
+    get: vi.fn((key: string) => storageState.values.get(key) ?? null),
+    set: vi.fn((key: string, value: unknown) => {
+      storageState.values.set(key, value);
+      return { success: true, bytes: 1 };
+    }),
+    safeJSON: vi.fn((key: string, fallback: unknown) => storageState.values.get(key) ?? fallback),
+    remove: vi.fn((key: string) => storageState.values.delete(key)),
+    keys: vi.fn(() => Array.from(storageState.values.keys())),
+  },
+}));
+
+vi.mock('../../pages/SettingsPage', async () => {
+  const React = await import('react');
+  const { default: WorkflowPreferencesPanel } = await import('../../components/settings/WorkflowPreferencesPanel');
+
+  return {
+    default: () => React.createElement(WorkflowPreferencesPanel),
+  };
+});
+
+vi.mock('../../components/fibromyalgia/FibromyalgiaTracker', () => ({
+  FibromyalgiaTracker: () => <div>Fibromyalgia tracker screen</div>,
+}));
+
+const visiblePreferences: WorkflowPreferences = {
+  defaultWcbTemplateStyle: 'hostile-bureaucracy',
+  industrialFieldMode: false,
+  showFibromyalgiaHubNavItem: true,
+};
+
+function mockPainTrackerStore() {
+  const storeState = {
+    entries: [
+      {
+        id: 'entry-1',
+        timestamp: new Date('2026-05-30T12:00:00.000Z').toISOString(),
+        baselineData: { pain: 5, locations: [], symptoms: [] },
+        notes: '',
+      },
+    ],
+    ui: { showOnboarding: false, showWalkthrough: false },
+    addEntry: vi.fn(),
+    updateEntry: vi.fn(),
+    setShowOnboarding: vi.fn(),
+    setShowWalkthrough: vi.fn(),
+    setError: vi.fn(),
+    loadSampleData: vi.fn(),
+  };
+
+  (usePainTrackerStore as unknown as { mockImplementation: (fn: unknown) => void }).mockImplementation(
+    (selector: unknown) => {
+      if (typeof selector === 'function') {
+        return (selector as (s: typeof storeState) => unknown)(storeState);
+      }
+
+      return storeState;
+    }
+  );
+}
+
+describe('PainTrackerContainer workflow preferences', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storageState.values.clear();
+    storageState.values.set(WORKFLOW_PREFERENCES_STORAGE_KEY, visiblePreferences);
+    mockPainTrackerStore();
+  });
+
+  it('updates the Fibromyalgia Hub shell navigation when the settings checkbox changes', async () => {
+    const user = userEvent.setup();
+
+    render(<PainTrackerContainer initialView="settings" />);
+
+    const fibromyalgiaNavPreference = await screen.findByRole('checkbox', {
+      name: /show fibromyalgia hub in navigation/i,
+    });
+    expect(fibromyalgiaNavPreference).toBeChecked();
+    expect(screen.getByRole('button', { name: /fibromyalgia hub/i })).toBeInTheDocument();
+
+    await user.click(fibromyalgiaNavPreference);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /fibromyalgia hub/i })).not.toBeInTheDocument();
+    });
+    expect(fibromyalgiaNavPreference).not.toBeChecked();
+    expect(screen.getByText(/workflow & field mode/i)).toBeInTheDocument();
+
+    await user.click(fibromyalgiaNavPreference);
+
+    expect(await screen.findByRole('button', { name: /fibromyalgia hub/i })).toBeInTheDocument();
+    expect(fibromyalgiaNavPreference).toBeChecked();
+  });
+
+  it('moves off the Fibromyalgia view when a live preference update hides that navigation item', async () => {
+    render(<PainTrackerContainer initialView="fibromyalgia" />);
+
+    expect(await screen.findByText('Fibromyalgia tracker screen')).toBeInTheDocument();
+
+    act(() => {
+      writeWorkflowPreferences({ showFibromyalgiaHubNavItem: false });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Clinical Dashboard')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Fibromyalgia tracker screen')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /fibromyalgia hub/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/__tests__/SettingsPage.test.tsx
+++ b/src/pages/__tests__/SettingsPage.test.tsx
@@ -22,6 +22,7 @@ describe('SettingsPage', () => {
 
     // Workflow preferences panel
     expect(screen.getByText(/Workflow & Field Mode/i)).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /Show Fibromyalgia Hub in navigation/i })).toBeInTheDocument();
 
     // Alerts settings
     expect(screen.getByText(/Alerts settings/i)).toBeInTheDocument();

--- a/src/utils/workflowPreferences.ts
+++ b/src/utils/workflowPreferences.ts
@@ -5,14 +5,17 @@ export type WcbTemplateStyle = 'standard' | 'hostile-bureaucracy';
 export interface WorkflowPreferences {
   defaultWcbTemplateStyle: WcbTemplateStyle;
   industrialFieldMode: boolean;
+  showFibromyalgiaHubNavItem: boolean;
 }
 
 export const DEFAULT_WORKFLOW_PREFERENCES: WorkflowPreferences = {
   defaultWcbTemplateStyle: 'hostile-bureaucracy',
   industrialFieldMode: false,
+  showFibromyalgiaHubNavItem: true,
 };
 
 export const WORKFLOW_PREFERENCES_STORAGE_KEY = 'pain-tracker:workflow-preferences';
+export const WORKFLOW_PREFERENCES_UPDATED_EVENT = 'workflow-preferences-updated';
 
 function coerceWorkflowPreferences(raw: unknown): WorkflowPreferences {
   const candidate = raw as Partial<WorkflowPreferences> | null | undefined;
@@ -27,7 +30,19 @@ function coerceWorkflowPreferences(raw: unknown): WorkflowPreferences {
       typeof candidate?.industrialFieldMode === 'boolean'
         ? candidate.industrialFieldMode
         : DEFAULT_WORKFLOW_PREFERENCES.industrialFieldMode,
+    showFibromyalgiaHubNavItem:
+      typeof candidate?.showFibromyalgiaHubNavItem === 'boolean'
+        ? candidate.showFibromyalgiaHubNavItem
+        : DEFAULT_WORKFLOW_PREFERENCES.showFibromyalgiaHubNavItem,
   };
+}
+
+function notifyWorkflowPreferencesUpdated(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.dispatchEvent(new Event(WORKFLOW_PREFERENCES_UPDATED_EVENT));
 }
 
 export function readWorkflowPreferences(): WorkflowPreferences {
@@ -44,6 +59,12 @@ export function writeWorkflowPreferences(
 ): WorkflowPreferences {
   const current = readWorkflowPreferences();
   const next = coerceWorkflowPreferences({ ...current, ...updates });
-  secureStorage.set(WORKFLOW_PREFERENCES_STORAGE_KEY, next);
+  const writeResult = secureStorage.set(WORKFLOW_PREFERENCES_STORAGE_KEY, next);
+
+  if (writeResult?.success === false) {
+    return current;
+  }
+
+  notifyWorkflowPreferencesUpdated();
   return next;
 }


### PR DESCRIPTION
## Summary

- Dispatch a local workflow-preferences update event after successful preference writes.
- Refresh the app shell from the workflow preference source of truth so toggling "Show Fibromyalgia Hub in navigation" updates navigation without a reload.
- Move users from the Fibromyalgia view back to the dashboard when a live preference update hides that route.
- Add regression coverage for live shell navigation updates and the active Fibromyalgia view fallback.

## Validation

- `npm run test -- --run src/containers/__tests__/PainTrackerContainer.workflow-preferences.test.tsx src/containers/__tests__/PainTrackerContainer.test.tsx src/pages/__tests__/SettingsPage.test.tsx`
- `npm run typecheck:ci`
- `npx eslint src/utils/workflowPreferences.ts src/containers/PainTrackerContainer.tsx src/containers/__tests__/PainTrackerContainer.workflow-preferences.test.tsx src/containers/__tests__/PainTrackerContainer.test.tsx src/components/settings/WorkflowPreferencesPanel.tsx src/components/layouts/ModernAppLayout.tsx src/pages/__tests__/SettingsPage.test.tsx`
- `git diff --check`