### PR TITLE
feat(onboarding): ship local-first First Entry Loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **First Entry Loop**: Pain Tracker now gives practical search visitors a direct first-entry path: log pain locally, confirm the saved record, export a printable report, or manually draft feedback without hidden submission or telemetry.
+
 ## [1.2.0] - 2026-01-18
 
 ### Added

--- a/e2e/tests/first-entry-loop.spec.ts
+++ b/e2e/tests/first-entry-loop.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test';
+
+test('resource visitor can save one local entry offline and reach bounded next actions', async ({
+  context,
+  page,
+}) => {
+  await context.addInitScript(() => {
+    localStorage.setItem('pt:test_mode', '1');
+    localStorage.setItem('pain-tracker-onboarding-completed', 'true');
+    localStorage.setItem('pt:pain-tracker-onboarding-completed', JSON.stringify('true'));
+    localStorage.setItem('pain_tracker_entries', '[]');
+    localStorage.setItem('pt:pain_tracker_entries', '[]');
+    localStorage.setItem('pain-tracker-notification-consent', 'declined');
+    localStorage.setItem('pain-tracker-analytics-consent', JSON.stringify({ consented: false }));
+  });
+
+  await page.goto('/resources/daily-pain-tracker-printable');
+
+  const startEntry = page.getByRole('link', { name: 'Start a private pain entry', exact: true });
+  await expect(startEntry).toBeVisible();
+  await startEntry.click();
+  await expect(page).toHaveURL(/\/app$/);
+
+  await expect(page.getByRole('heading', { name: 'First Pain Entry', exact: true })).toBeVisible();
+  await expect(page.getByText(/No account is required/i)).toBeVisible();
+
+  const suspiciousRequests: string[] = [];
+  let observeSaveRequests = false;
+  page.on('request', request => {
+    if (!observeSaveRequests) return;
+    if (!['fetch', 'xhr'].includes(request.resourceType())) return;
+
+    const url = request.url();
+    if (
+      /analytics|collect|feedback|intake|weather/i.test(url) ||
+      !url.startsWith('http://localhost:3000')
+    ) {
+      suspiciousRequests.push(url);
+    }
+  });
+
+  await context.setOffline(true);
+  observeSaveRequests = true;
+  await page.getByRole('button', { name: /^(log pain now|save( and finish)?( entry)?)$/i }).click();
+
+  const confirmation = page.getByRole('region', { name: /Saved on this device/i });
+  await expect(confirmation).toBeVisible();
+  await expect(confirmation).toBeFocused();
+
+  const nextActions = page.getByRole('group', { name: 'Next actions' });
+  await expect(nextActions.getByRole('button')).toHaveCount(3);
+  await expect(nextActions.getByRole('button', { name: 'Add another entry' })).toBeVisible();
+  await expect(nextActions.getByRole('button', { name: 'Export printable report' })).toBeVisible();
+  await expect(nextActions.getByRole('button', { name: 'Draft feedback manually' })).toBeVisible();
+  expect(suspiciousRequests).toEqual([]);
+
+  await nextActions.getByRole('button', { name: 'Draft feedback manually' }).click();
+  await expect(page.getByText(/Email may reveal your address/i)).toBeVisible();
+  await expect(page.getByText(/stays on your device until you copy it/i)).toBeVisible();
+
+  observeSaveRequests = false;
+  await context.setOffline(false);
+  await nextActions.getByRole('button', { name: 'Export printable report' }).click();
+  await expect(page.getByRole('heading', { name: 'Reports & Export' })).toBeVisible();
+});

--- a/e2e/tests/smoke-navigation.spec.ts
+++ b/e2e/tests/smoke-navigation.spec.ts
@@ -67,9 +67,12 @@ test.describe('smoke: navigation + load stability', () => {
 
     await page.goto('/resources/what-to-include-in-pain-journal', { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByRole('heading', { name: /what to include in a pain journal/i })).toBeVisible({
-      timeout: 30_000,
-    });
+    await expect(
+      page.getByRole('heading', {
+        level: 1,
+        name: /what to include in a pain journal/i,
+      })
+    ).toBeVisible({ timeout: 30_000 });
 
     expect(pageErrors, 'no pageerror exceptions').toEqual([]);
   });

--- a/src/components/onboarding/FirstEntrySuccessPanel.test.tsx
+++ b/src/components/onboarding/FirstEntrySuccessPanel.test.tsx
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '../../test/test-utils';
+import { FirstEntrySuccessPanel } from './FirstEntrySuccessPanel';
+
+describe('FirstEntrySuccessPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('requires an explicit user action before preparing feedback for another app', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.spyOn(navigator.clipboard, 'writeText');
+
+    render(
+      <FirstEntrySuccessPanel entryCount={1} onAddAnother={vi.fn()} onExportReport={vi.fn()} />
+    );
+
+    const confirmation = screen.getByRole('region', { name: /saved on this device/i });
+    expect(confirmation).toHaveFocus();
+    expect(writeText).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: /draft feedback manually/i }));
+    await user.type(
+      screen.getByRole('textbox', { name: /what almost stopped you/i }),
+      'The first save button was hard to find.'
+    );
+
+    expect(writeText).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: /copy draft/i }));
+
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining('No pain entry data is attached by this screen.')
+    );
+  });
+});

--- a/src/components/onboarding/FirstEntrySuccessPanel.tsx
+++ b/src/components/onboarding/FirstEntrySuccessPanel.tsx
@@ -1,0 +1,195 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { CheckCircle2, Clipboard, FileText, Mail, Plus, ShieldCheck } from 'lucide-react';
+
+interface FirstEntrySuccessPanelProps {
+  entryCount: number;
+  onAddAnother: () => void;
+  onExportReport: () => void;
+}
+
+const SUPPORT_EMAIL = 'support@paintracker.ca';
+const FEEDBACK_MAX_LENGTH = 600;
+
+function buildFeedbackDraft(feedback: string) {
+  return [
+    'What almost stopped you from using PainTracker?',
+    '',
+    feedback.trim(),
+    '',
+    'Context: first entry completed. No pain entry data is attached by this screen.',
+  ].join('\n');
+}
+
+function buildMailtoHref(feedback: string) {
+  const subject = 'PainTracker first-entry feedback';
+  const body = buildFeedbackDraft(feedback);
+  return `mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+}
+
+export function FirstEntrySuccessPanel({
+  entryCount,
+  onAddAnother,
+  onExportReport,
+}: Readonly<FirstEntrySuccessPanelProps>) {
+  const confirmationRef = useRef<HTMLElement>(null);
+  const [showFeedbackDraft, setShowFeedbackDraft] = useState(false);
+  const [feedback, setFeedback] = useState('');
+  const [feedbackStatus, setFeedbackStatus] = useState<string | null>(null);
+  const trimmedFeedback = feedback.trim();
+
+  useEffect(() => {
+    confirmationRef.current?.focus();
+  }, []);
+
+  const copyFeedbackDraft = async () => {
+    if (!trimmedFeedback) {
+      setFeedbackStatus('Write a short note first. Nothing has been sent.');
+      return;
+    }
+
+    if (!navigator.clipboard?.writeText) {
+      setFeedbackStatus('Clipboard is unavailable. Select and copy the draft manually.');
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(buildFeedbackDraft(feedback));
+      setFeedbackStatus('Draft copied. You choose where to send it.');
+    } catch {
+      setFeedbackStatus('Copy failed. Select and copy the draft manually.');
+    }
+  };
+
+  const openEmailDraft = () => {
+    if (!trimmedFeedback) {
+      setFeedbackStatus('Write a short note first. Nothing has been sent.');
+      return;
+    }
+
+    globalThis.location.href = buildMailtoHref(feedback);
+    setFeedbackStatus('Email draft opened. Review it before sending.');
+  };
+
+  return (
+    <section
+      ref={confirmationRef}
+      tabIndex={-1}
+      className="mx-auto max-w-4xl space-y-6 py-4 focus:outline-none"
+      aria-labelledby="first-entry-success-heading"
+    >
+      <div className="rounded-lg border border-emerald-500/25 bg-emerald-500/10 p-6 shadow-sm">
+        <div className="flex gap-4">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-emerald-500 text-slate-950">
+            <CheckCircle2 className="h-6 w-6" aria-hidden="true" />
+          </div>
+          <div>
+            <p className="mb-2 text-sm font-semibold uppercase tracking-wide text-emerald-300">
+              First entry saved
+            </p>
+            <div role="status" aria-live="polite" aria-atomic="true">
+              <h1
+                id="first-entry-success-heading"
+                className="text-2xl font-bold tracking-tight text-foreground"
+              >
+                Saved on this device.
+              </h1>
+              <p className="mt-3 max-w-2xl text-sm leading-relaxed text-muted-foreground">
+                Your record is available locally without an account. Nothing was submitted as
+                feedback, and no pain entry is attached to the optional draft below.
+              </p>
+            </div>
+            <p className="mt-2 text-xs text-muted-foreground">
+              Saved entries: {Math.max(entryCount, 1)}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-6 grid gap-3 sm:grid-cols-3" role="group" aria-label="Next actions">
+          <button
+            type="button"
+            onClick={onAddAnother}
+            className="inline-flex min-h-12 items-center justify-center gap-2 rounded-lg bg-primary px-4 py-3 text-sm font-semibold text-primary-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background"
+          >
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            Add another entry
+          </button>
+          <button
+            type="button"
+            onClick={onExportReport}
+            className="inline-flex min-h-12 items-center justify-center gap-2 rounded-lg border border-border bg-background px-4 py-3 text-sm font-semibold text-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background"
+          >
+            <FileText className="h-4 w-4" aria-hidden="true" />
+            Export printable report
+          </button>
+          <button
+            type="button"
+            aria-expanded={showFeedbackDraft}
+            aria-controls="first-entry-feedback-panel"
+            onClick={() => setShowFeedbackDraft(value => !value)}
+            className="inline-flex min-h-12 items-center justify-center gap-2 rounded-lg border border-border bg-background px-4 py-3 text-sm font-semibold text-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background"
+          >
+            <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+            Draft feedback manually
+          </button>
+        </div>
+      </div>
+
+      {showFeedbackDraft && (
+        <div
+          id="first-entry-feedback-panel"
+          className="rounded-lg border border-border/60 bg-card p-6"
+        >
+          <h2 className="text-xl font-semibold text-foreground">Optional feedback draft</h2>
+          <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+            This text stays on your device until you copy it or open an email draft. Email may
+            reveal your address, mail provider, IP address, or other message metadata. Do not
+            include health details you do not want to disclose.
+          </p>
+
+          <label htmlFor="first-entry-feedback" className="sr-only">
+            What almost stopped you from using PainTracker?
+          </label>
+          <textarea
+            id="first-entry-feedback"
+            value={feedback}
+            onChange={event => {
+              setFeedback(event.currentTarget.value);
+              setFeedbackStatus(null);
+            }}
+            maxLength={FEEDBACK_MAX_LENGTH}
+            rows={5}
+            placeholder="What almost stopped you from using PainTracker?"
+            className="mt-4 min-h-32 w-full rounded-lg border border-input bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+
+          <div className="mt-3 flex flex-col gap-3 sm:flex-row">
+            <button
+              type="button"
+              onClick={copyFeedbackDraft}
+              className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg border border-border bg-background px-4 py-2.5 text-sm font-semibold text-foreground"
+            >
+              <Clipboard className="h-4 w-4" aria-hidden="true" />
+              Copy draft
+            </button>
+            <button
+              type="button"
+              onClick={openEmailDraft}
+              className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg border border-border bg-background px-4 py-2.5 text-sm font-semibold text-foreground"
+            >
+              <Mail className="h-4 w-4" aria-hidden="true" />
+              Open email draft
+            </button>
+          </div>
+
+          {feedbackStatus && (
+            <p className="mt-3 text-sm text-muted-foreground" role="status" aria-live="polite">
+              {feedbackStatus}
+            </p>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default FirstEntrySuccessPanel;

--- a/src/containers/PainTrackerContainer.tsx
+++ b/src/containers/PainTrackerContainer.tsx
@@ -11,6 +11,7 @@ import { maybeCaptureWeatherForNewEntry } from '../services/weatherAutoCapture';
 import { EmptyStatePanel } from '../components/widgets/EmptyStatePanel';
 import { BrandedLoadingScreen } from '../components/branding/BrandedLoadingScreen';
 import { HistoryPage } from '../components/history/HistoryPage';
+import { FirstEntrySuccessPanel } from '../components/onboarding/FirstEntrySuccessPanel';
 import { subscriptionService } from '../services/SubscriptionService';
 import { getLocalUserId } from '../utils/user-identity';
 import {
@@ -80,6 +81,7 @@ export function PainTrackerContainer({ initialView }: { initialView?: string } =
   });
   const [editingEntryId, setEditingEntryId] = useState<PainEntry['id'] | null>(null);
   const [onboardingDemoEntries, setOnboardingDemoEntries] = useState<PainEntry[] | null>(null);
+  const [firstEntryCompletionCount, setFirstEntryCompletionCount] = useState<number | null>(null);
   const isOnboardingDemoActive = onboardingDemoEntries !== null && entries.length === 0;
 
   useEffect(() => {
@@ -218,6 +220,10 @@ export function PainTrackerContainer({ initialView }: { initialView?: string } =
   };
 
   const handleNavigate = (nextView: string) => {
+    if (nextView !== 'first-entry-success') {
+      setFirstEntryCompletionCount(null);
+    }
+
     if (nextView === 'fibromyalgia' && !workflowPreferences.showFibromyalgiaHubNavItem) {
       setCurrentView('dashboard');
       return;
@@ -273,6 +279,7 @@ export function PainTrackerContainer({ initialView }: { initialView?: string } =
       };
 
       const beforeCount = storeApi.getState?.()?.entries?.length ?? entries.length;
+      const isFirstSavedEntry = beforeCount === 0;
       if (onboardingDemoEntries !== null) {
         setOnboardingDemoEntries(null);
       }
@@ -281,7 +288,7 @@ export function PainTrackerContainer({ initialView }: { initialView?: string } =
       // Best-effort: enrich the just-saved entry with local weather (opt-in).
       // This must never block saving the entry.
       const created = storeApi.getState?.()?.entries?.[beforeCount];
-      if (created) {
+      if (created && !isFirstSavedEntry) {
         void (async () => {
           const captured = await maybeCaptureWeatherForNewEntry();
           if (!captured) return;
@@ -290,12 +297,20 @@ export function PainTrackerContainer({ initialView }: { initialView?: string } =
       }
       setError(null);
       toast.success(
-        'Entry saved',
-        "Your update is safely stored. You can explore your dashboard or analytics whenever you're ready."
+        isFirstSavedEntry ? 'Saved on this device' : 'Entry saved',
+        isFirstSavedEntry
+          ? 'Your first entry is stored locally. Nothing was submitted to a feedback service.'
+          : "Your update is safely stored. You can explore your dashboard or analytics whenever you're ready."
       );
       // Navigate back to dashboard after saving unless caller requested staying on the save view
       if (!options?.stayOnSave) {
-        setCurrentView('dashboard');
+        if (isFirstSavedEntry) {
+          setFirstEntryCompletionCount(beforeCount + 1);
+          setCurrentView('first-entry-success');
+        } else {
+          setFirstEntryCompletionCount(null);
+          setCurrentView('dashboard');
+        }
       }
     } catch (err) {
       setError('Failed to add pain entry. Please try again.');
@@ -344,6 +359,7 @@ export function PainTrackerContainer({ initialView }: { initialView?: string } =
       case 'new-entry':
         return (
           <QuickLogOneScreen
+            firstEntryMode={entries.length === 0}
             interactionMode={industrialFieldMode ? 'industrial' : 'standard'}
             onComplete={data => {
               const entryToAdd: Omit<PainEntry, 'id' | 'timestamp'> = {
@@ -397,6 +413,21 @@ export function PainTrackerContainer({ initialView }: { initialView?: string } =
               handleAddEntry(entryToAdd);
             }}
             onCancel={() => setCurrentView('dashboard')}
+          />
+        );
+
+      case 'first-entry-success':
+        return (
+          <FirstEntrySuccessPanel
+            entryCount={firstEntryCompletionCount ?? entries.length}
+            onAddAnother={() => {
+              setFirstEntryCompletionCount(null);
+              setCurrentView('new-entry');
+            }}
+            onExportReport={() => {
+              setFirstEntryCompletionCount(null);
+              setCurrentView('reports');
+            }}
           />
         );
 

--- a/src/containers/__tests__/PainTrackerContainer.test.tsx
+++ b/src/containers/__tests__/PainTrackerContainer.test.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
+import { within } from '@testing-library/react';
 import { render, screen, waitFor } from '../../test/test-utils';
 import { PainTrackerContainer } from '../PainTrackerContainer';
 import { usePainTrackerStore } from '../../stores/pain-tracker-store';
 import { readWorkflowPreferences } from '../../utils/workflowPreferences';
+import { maybeCaptureWeatherForNewEntry } from '../../services/weatherAutoCapture';
 
 vi.mock('../../stores/pain-tracker-store');
 vi.mock('../../utils/workflowPreferences', () => ({
@@ -34,13 +36,16 @@ type QuickLogOneScreenData = {
 
 vi.mock('../../design-system/fused-v2/QuickLogOneScreen', () => ({
   default: function QuickLogOneScreenMock({
+    firstEntryMode,
     onComplete,
   }: {
+    firstEntryMode?: boolean;
     onComplete: (data: QuickLogOneScreenData) => void;
   }) {
     const [checked, setChecked] = React.useState(false);
     return (
       <div>
+        <h2>{firstEntryMode ? 'First Pain Entry' : 'Quick Log'}</h2>
         <label>
           <input
             type="checkbox"
@@ -73,11 +78,17 @@ vi.mock('../../data/sampleData', () => ({
 }));
 
 vi.mock('../../services/weatherAutoCapture', () => ({
-  maybeCaptureWeatherForNewEntry: async () => null,
+  maybeCaptureWeatherForNewEntry: vi.fn(async () => null),
 }));
 
 vi.mock('../../pages/SettingsPage', () => ({
   default: () => <h2>Settings Surface</h2>,
+}));
+
+vi.mock('../../components/reports', () => ({
+  ReportsPage: ({ entries }: { entries: unknown[] }) => (
+    <div>Reports surface entries: {entries.length}</div>
+  ),
 }));
 
 // Mock secureStorage to avoid real storage access
@@ -92,6 +103,10 @@ vi.mock('../../lib/storage/secureStorage', () => ({
 }));
 
 describe('PainTrackerContainer - entry success toast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('opens settings from the app navigation', async () => {
     vi.mocked(readWorkflowPreferences).mockReturnValue({
       defaultWcbTemplateStyle: 'hostile-bureaucracy',
@@ -205,8 +220,58 @@ describe('PainTrackerContainer - entry success toast', () => {
 
     render(<PainTrackerContainer />);
 
-    expect(await screen.findByRole('button', { name: /log pain now/i })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /first pain entry/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /log pain now/i })).toBeInTheDocument();
   });
+
+  it('confirms the first local save, focuses it, and exposes only the three bounded next actions', async () => {
+    const user = userEvent.setup();
+    const addEntry = vi.fn();
+    const storeState = {
+      entries: [],
+      ui: { showOnboarding: false, showWalkthrough: false },
+      addEntry,
+      updateEntry: vi.fn(),
+      setShowOnboarding: vi.fn(),
+      setShowWalkthrough: vi.fn(),
+      setError: vi.fn(),
+      loadSampleData: vi.fn(),
+    };
+
+    (usePainTrackerStore as unknown as { mockImplementation: (fn: unknown) => void }).mockImplementation(
+      (selector: unknown) => {
+        if (typeof selector === 'function') {
+          return (selector as (s: typeof storeState) => unknown)(storeState);
+        }
+        return storeState;
+      }
+    );
+
+    render(<PainTrackerContainer />);
+
+    await user.click(await screen.findByRole('checkbox', { name: /lower back location/i }));
+    await user.click(screen.getByRole('button', { name: /log pain now/i }));
+
+    expect(addEntry).toHaveBeenCalledTimes(1);
+    expect(maybeCaptureWeatherForNewEntry).not.toHaveBeenCalled();
+
+    const confirmation = await screen.findByRole('region', { name: /saved on this device/i });
+    expect(confirmation).toHaveFocus();
+    expect(screen.getByText(/available locally without an account/i)).toBeInTheDocument();
+
+    const nextActions = screen.getByRole('group', { name: /next actions/i });
+    expect(within(nextActions).getAllByRole('button')).toHaveLength(3);
+    expect(within(nextActions).getByRole('button', { name: /add another entry/i })).toBeInTheDocument();
+    expect(within(nextActions).getByRole('button', { name: /export printable report/i })).toBeInTheDocument();
+    expect(within(nextActions).getByRole('button', { name: /draft feedback manually/i })).toBeInTheDocument();
+
+    await user.click(within(nextActions).getByRole('button', { name: /draft feedback manually/i }));
+    expect(screen.getByText(/email may reveal your address/i)).toBeInTheDocument();
+    expect(screen.getByText(/stays on your device until you copy it/i)).toBeInTheDocument();
+
+    await user.click(within(nextActions).getByRole('button', { name: /export printable report/i }));
+    expect(await screen.findByText(/reports surface entries/i)).toBeInTheDocument();
+  }, 30000);
 
   it('shows gentle success toast after a valid entry is added', async () => {
     vi.mocked(readWorkflowPreferences).mockReturnValue({

--- a/src/design-system/fused-v2/QuickLogOneScreen.tsx
+++ b/src/design-system/fused-v2/QuickLogOneScreen.tsx
@@ -34,6 +34,7 @@ export type QuickLogOneScreenData = {
 
 interface QuickLogOneScreenProps {
   mode?: 'new' | 'edit';
+  firstEntryMode?: boolean;
   interactionMode?: 'standard' | 'industrial';
   initialData?: Partial<QuickLogOneScreenData>;
   onComplete: (data: QuickLogOneScreenData) => void;
@@ -171,8 +172,9 @@ function getVoiceToggleLabel(voiceMode: boolean) {
   return voiceMode ? 'Voice On' : 'Voice';
 }
 
-function getQuickLogHeading(mode: 'new' | 'edit') {
-  return mode === 'edit' ? 'Edit Log' : 'Quick Log';
+function getQuickLogHeading(mode: 'new' | 'edit', firstEntryMode: boolean) {
+  if (mode === 'edit') return 'Edit Log';
+  return firstEntryMode ? 'First Pain Entry' : 'Quick Log';
 }
 
 function getVoiceNoteFileName() {
@@ -707,6 +709,7 @@ function useAudioNoteRecorder() {
 
 export function QuickLogOneScreen({
   mode = 'new',
+  firstEntryMode = false,
   interactionMode = 'standard',
   initialData,
   onComplete,
@@ -787,7 +790,7 @@ export function QuickLogOneScreen({
   };
 
   const handlePainChange = (value: number) => setPain(value);
-  const quickLogHeading = getQuickLogHeading(mode);
+  const quickLogHeading = getQuickLogHeading(mode, firstEntryMode);
 
   const hasNavigator = typeof navigator !== 'undefined';
   const isOffline = hasNavigator && navigator.onLine === false;
@@ -881,6 +884,16 @@ export function QuickLogOneScreen({
       {/* Content */}
       <div className="flex-1 overflow-y-auto p-6">
         <div className="max-w-2xl mx-auto space-y-10">
+          {firstEntryMode && mode === 'new' && (
+            <section className="rounded-[var(--radius-xl)] border border-primary-500/35 bg-primary-500/10 p-5">
+              <h2 className="text-h2 text-ink-50 mb-2">One local record is enough to start.</h2>
+              <p className="text-small leading-relaxed text-ink-300">
+                No account is required. Choose a pain level and save now; location, symptoms, and
+                notes are optional.
+              </p>
+            </section>
+          )}
+
           {/* Pain */}
           <section className="space-y-5">
             <div>

--- a/src/pages/resources/DailyPainTrackerPrintablePage.tsx
+++ b/src/pages/resources/DailyPainTrackerPrintablePage.tsx
@@ -62,7 +62,7 @@ const SEO = {
   title: 'Daily Pain Tracker Printable in 2026',
   metaTitle: 'Daily Pain Tracker Printable (2026) | Free PDF, No Email Required',
   metaDescription:
-    'Download the free daily pain tracker printable PDF for 2026. No email required. Record pain levels, medications, flare ups, triggers, daily limits, mood, and notes for doctor visits.',
+    'Download the free daily pain tracker printable PDF for 2026, or create one searchable local record in the app. No account or email required.',
   keywords: [
     'daily pain tracker printable',
     'daily pain log',
@@ -532,7 +532,7 @@ export const DailyPainTrackerPrintablePage: React.FC = () => {
             </p>
             <p className="text-slate-300 text-base sm:text-lg max-w-2xl mx-auto mb-4">
               Start on paper if that is the easiest move today. Use the free app instead when you
-              want less manual summarizing and a record that stays searchable on your device.
+              want one searchable record saved on this device, with an export path when you need it.
             </p>
             <p className="text-slate-500 text-sm mb-8">
               100% free &bull; No email required &bull; No tracking &bull; Prints on standard letter
@@ -554,7 +554,7 @@ export const DailyPainTrackerPrintablePage: React.FC = () => {
                 className="px-8 py-4 text-lg font-medium text-slate-300 hover:text-white border border-slate-600 hover:border-slate-500 rounded-xl transition-all flex items-center gap-2"
               >
                 <Sparkles className="w-5 h-5" />
-                Use the free app instead
+                Start a private pain entry
               </Link>
             </div>
 


### PR DESCRIPTION
## Summary

Ships one narrow activation chain from `/resources/daily-pain-tracker-printable` to a first local record, explicit save confirmation, export, and manually initiated feedback drafting.

- 9 changed files
- 428 additions / 16 deletions (412 net lines)
- No crypto, storage migration, payment, publishing, broad SEO, or infrastructure changes
- Supersedes the First Entry portion of #173; that mega-PR must not be merged as-is

## User path

1. Open the daily pain tracker printable resource page.
2. Choose **Start a private pain entry**.
3. Save the one-screen entry with only the default pain level required.
4. Receive **Saved on this device.** with focus and screen-reader announcement.
5. Choose one of three next actions: add another entry, export a printable report, or draft feedback manually.

## Privacy boundary

- No account is required.
- The release adds no telemetry event or background intake.
- First-save weather enrichment is skipped, so normal first-record creation cannot initiate that optional network path.
- Feedback is never submitted automatically. Copy and `mailto:` remain explicit user actions.
- The feedback panel warns that email may reveal address, provider, IP, or message metadata.
- No pain entry is attached to the feedback draft.

## Protective audit

1. **Assumed vulnerability state:** pain, fatigue, cognitive overload, interruption, and unstable connectivity.
2. **No internet:** the focused browser smoke saves successfully after the app is loaded and the browser is forced offline.
3. **Interrupted mid-action:** no destructive mutation or remote transaction is introduced; the existing local save remains the only write.
4. **Shared or coerced device:** the confirmation uses neutral copy and does not reveal entry details.
5. **New exposure:** only user-authored feedback can leave the device, after an explicit copy or email-draft action and metadata warning.
6. **Local reversal:** no deletion or migration is introduced; the PR is one reversible commit.
7. **Backup/export:** the existing report route is reachable directly after save without re-entering data.
8. **Restore meaning:** no schema, backup, import, or restore behavior changes.
9. **Silent failure/loss:** save errors stay on the existing error path; success is shown only after `addEntry` returns.
10. **Third-party trust:** no new dependency, service, or required remote boundary is added.
11. **Degraded core task:** offline first-save behavior is covered by Playwright.
12. **Cognitive demand:** the initial form states the minimum requirement and the confirmation limits the next step to three actions.
13. **Safety proof:** focused unit tests, 48 privacy gates, typecheck, production build, focused offline browser smoke, and the three-browser smoke suite pass.
14. **Documentation truthfulness:** the changelog describes only the implemented local-save/manual-feedback behavior.
15. **Optional subsystem failure:** weather enrichment is bypassed for the first save; export and email drafting remain user-initiated next steps.

## Verification

- `npx vitest run src/containers/__tests__/PainTrackerContainer.test.tsx src/components/onboarding/FirstEntrySuccessPanel.test.tsx` - 6 passed
- `npm run test:privacy-gates` - 48 passed
- `npm run typecheck:ci` - passed
- `npm run build` - passed; 121 routes prerendered
- `npx playwright test e2e/tests/first-entry-loop.spec.ts --project=chromium --config=e2e/playwright.config.ts --workers=1` - 1 passed
- `npm run e2e:smoke` - 6 passed across Chromium, mobile Chrome, and mobile Safari
- GitHub Actions jobs did not execute: check-run annotations report that the account is locked due to a billing issue. Vercel and Cloudflare previews succeeded; local verification above is the code evidence.

## Preview smoke

Verified on [Vercel preview](https://pain-tracker-git-release-first-505667-kalyim-overton-s-projects.vercel.app/resources/daily-pain-tracker-printable):

- Exact **Start a private pain entry** CTA opens the protected quick-log path.
- Created one disposable entry using only the default pain level.
- Confirmation moved focus to **Saved on this device.** and exposed exactly three next actions.
- Feedback stayed collapsed until requested and then disclosed email address/provider/IP/message metadata risk.
- Export opened **Reports & Export** with `Total Entries: 1` without re-entering the record.
- After refresh and vault unlock, header stats remained `5.0 avg / 1 day streak`; History showed `1 total` and the saved `Pain 5/10` entry.
- Browser console contained no errors or warnings during the resource, save, feedback, export, refresh, or History path.
- The focused Playwright smoke separately forced the browser offline during save and recorded no suspicious telemetry, intake, feedback, weather, or cross-origin fetch/XHR request.

Evidence screenshots were captured for the deployed CTA and refreshed History entry.

## Production verification

Verified after merge commit `d44fffa8efb6f00034bd4a572f69f5fb65875655` was deployed successfully by Vercel and Cloudflare:

- Canonical route: https://www.paintracker.ca/resources/daily-pain-tracker-printable
- Exact **Start a private pain entry** CTA is live and reaches `/start` without a 404.
- Created one disposable local entry with the minimum form state.
- **Saved on this device.** received focus and exposed exactly three next actions.
- **Reports & Export** showed `Total Entries: 1` without re-entry.
- After refresh and vault unlock, `5.0 avg / 1 day streak` remained and History showed the saved `Pain 5/10` entry.
- Browser console had no errors or warnings across the production path.
- Merge used the explicitly authorized admin override because GitHub Actions jobs were prevented from starting by the account billing lock.

## Rollback

Revert commit `25510d12`. The release contains no migration, remote data change, or new dependency.
